### PR TITLE
Update platformio.ini

### DIFF
--- a/ESP8266 VR OSC Haptics/platformio.ini
+++ b/ESP8266 VR OSC Haptics/platformio.ini
@@ -13,7 +13,8 @@ platform = espressif8266
 board = esp12e
 framework = arduino
 lib_deps = 
-	hideakitai/ArduinoOSC@^0.3.29
+	hideakitai/ArduinoOSC@^0.4.0
 	adafruit/Adafruit DRV2605 Library @ ^1.2.4
 monitor_speed = 115200
 upload_speed = 921600
+


### PR DESCRIPTION
Needed to update ArduinoOSC because 0.3.29 started producing this error at some point.

> UnknownPackageError: Could not find the package with 'hideakitai/ArduinoOSC @ ^0.3.29' requirements for your system 'windows_amd64'

0.4.0 Works just fine and has packages available for windows_amd64.